### PR TITLE
Credit author of glsl-component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # RayCasting3D
+
+### Dependencies
+[glsl-component.js](https://github.com/PixelsCommander/glsl-component/) — [MIT](https://mit-license.org/) Copyright 2017 Denis Radin aka PixelsCommander


### PR DESCRIPTION
That source code licensed under MIT, which requires to include copyright inclusion.
Usually it's done by adding a comment in the beginning of the source. But PixelsCommander just added license to Readme. So I propose to do the same thing.